### PR TITLE
Add inbound pausing for eBTC bridge

### DIFF
--- a/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
@@ -162,6 +162,8 @@ abstract contract CrossChainTellerWithGenericBridge is TellerWithMultiAssetSuppo
      *         message has been confirmed as legit.`
      */
     function _completeMessageReceive(bytes32 messageId, uint256 message) internal {
+        if (isPaused) revert TellerWithMultiAssetSupport__Paused();
+
         MessageLib.Message memory m = message.uint256ToMessage();
 
         // Mint shares to message.to


### PR DESCRIPTION
Currently, if hypernative detects an issue and pauses our contracts, any malicious transactions currently in flight will still be confirmed on the destination chain. This pr fixes that  